### PR TITLE
Add today_birthday and today_family_holiday sensors

### DIFF
--- a/custom_components/cz_sk_calendar/sensor.py
+++ b/custom_components/cz_sk_calendar/sensor.py
@@ -262,6 +262,9 @@ async def async_setup_entry(
     CZSKNextSpecialDaySensor(config_entry, country),
     CZSKNextBirthdaySensor(config_entry, country),
     CZSKNextFamilyHolidaySensor(config_entry, country),
+        # Today's custom event sensors
+        CZSKTodayBirthdaySensor(config_entry, country),
+        CZSKTodayFamilyHolidaySensor(config_entry, country),
         # Countdown sensors
         CZSKDaysToHolidaySensor(config_entry, country),
         CZSKDaysToVacationSensor(config_entry, country, region),
@@ -596,6 +599,54 @@ class CZSKNextFamilyHolidaySensor(CZSKBaseSensor):
             attrs["in_reminder_window"] = in_window
             attrs["should_notify"] = should_notify
 
+        return attrs
+
+
+class CZSKTodayBirthdaySensor(CZSKBaseSensor):
+    """Sensor for today's birthday from custom birthday list."""
+
+    def __init__(self, config_entry: ConfigEntry, country: str) -> None:
+        """Initialize the today's birthday sensor."""
+        name = "Dnešní narozeniny" if country == COUNTRY_CZ else "Dnešné narodeniny"
+        super().__init__(config_entry, "today_birthday", name, "mdi:cake-variant")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return today's birthday name or None."""
+        return _get_custom_event_name(self.today, self._custom_birthdays)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional attributes."""
+        attrs = super().extra_state_attributes.copy()
+        name = _get_custom_event_name(self.today, self._custom_birthdays)
+        attrs["has_birthday"] = name is not None
+        if name:
+            attrs["name"] = name
+        return attrs
+
+
+class CZSKTodayFamilyHolidaySensor(CZSKBaseSensor):
+    """Sensor for today's family holiday from custom holiday list."""
+
+    def __init__(self, config_entry: ConfigEntry, country: str) -> None:
+        """Initialize the today's family holiday sensor."""
+        name = "Dnešní rodinný svátek" if country == COUNTRY_CZ else "Dnešný rodinný sviatok"
+        super().__init__(config_entry, "today_family_holiday", name, "mdi:party-popper")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return today's family holiday name or None."""
+        return _get_custom_event_name(self.today, self._custom_holidays)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional attributes."""
+        attrs = super().extra_state_attributes.copy()
+        name = _get_custom_event_name(self.today, self._custom_holidays)
+        attrs["has_holiday"] = name is not None
+        if name:
+            attrs["name"] = name
         return attrs
 
 

--- a/custom_components/cz_sk_calendar/translations/cs.json
+++ b/custom_components/cz_sk_calendar/translations/cs.json
@@ -62,11 +62,17 @@
       "days_to_birthday": {
         "name": "Dní do narozenin"
       },
+      "today_birthday": {
+        "name": "Dnešní narozeniny"
+      },
       "next_family_holiday": {
         "name": "Příští rodinný svátek"
       },
       "days_to_family_holiday": {
         "name": "Dní do rodinného svátku"
+      },
+      "today_family_holiday": {
+        "name": "Dnešní rodinný svátek"
       },
       "vacation_name": {
         "name": "Název prázdnin"

--- a/custom_components/cz_sk_calendar/translations/en.json
+++ b/custom_components/cz_sk_calendar/translations/en.json
@@ -62,11 +62,17 @@
       "days_to_birthday": {
         "name": "Days to Birthday"
       },
+      "today_birthday": {
+        "name": "Today's Birthday"
+      },
       "next_family_holiday": {
         "name": "Next Family Holiday"
       },
       "days_to_family_holiday": {
         "name": "Days to Family Holiday"
+      },
+      "today_family_holiday": {
+        "name": "Today's Family Holiday"
       },
       "vacation_name": {
         "name": "Vacation Name"

--- a/custom_components/cz_sk_calendar/translations/sk.json
+++ b/custom_components/cz_sk_calendar/translations/sk.json
@@ -62,11 +62,17 @@
       "days_to_birthday": {
         "name": "Dní do narodenín"
       },
+      "today_birthday": {
+        "name": "Dnešné narodeniny"
+      },
       "next_family_holiday": {
         "name": "Ďalší rodinný sviatok"
       },
       "days_to_family_holiday": {
         "name": "Dní do rodinného sviatku"
+      },
+      "today_family_holiday": {
+        "name": "Dnešný rodinný sviatok"
       },
       "vacation_name": {
         "name": "Názov prázdnin"


### PR DESCRIPTION
New sensors showing today's events from custom lists:
- CZSKTodayBirthdaySensor (today_birthday): returns name(s) of birthdays today
- CZSKTodayFamilyHolidaySensor (today_family_holiday): returns name(s) of family holidays today

Both sensors return None when no event is today, include has_birthday/has_holiday attribute for easy automations, and have full CZ/SK/EN translations.
