### PR TITLE
Opravit zacyklený atribut vacations a rozšířit jmeniny

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,30 @@ V možnostech integrace nastavíte:
 | `sensor.days_to_holiday` | Dní do příštího svátku | číslo |
 | `sensor.days_to_special_day` | Dní do příštího významného dne | číslo |
 | `sensor.days_to_vacation` | Dní do příštích prázdnin | číslo |
+| `sensor.nameday` | Jmeniny / meniny dneška | text nebo `None` |
+| `sensor.nameday_tomorrow` | Jmeniny / meniny zítřka | text nebo `None` |
+| `sensor.nameday_day_after_tomorrow` | Jmeniny / meniny pozítřka | text nebo `None` |
+
+### Jmeniny / meniny
+
+Senzory jmenin zobrazují **všechna jména daného dne**. Slovenský kalendář jich má
+na řadě dní víc než jedno (např. 2. 9. „Linda, Rebeka“) – stav senzoru pak
+obsahuje všechna, oddělená čárkou. Jednotlivá jména najdete i v atributech:
+
+| Atribut | Popis |
+|---------|-------|
+| `names` | Seznam jmen, např. `["Linda", "Rebeka"]` |
+| `names_count` | Počet jmen daného dne |
+| `date` | Datum, ke kterému se senzor vztahuje |
+| `offset_days` | 0 = dnes, 1 = zítra, 2 = pozítří |
+
+```yaml
+# Všechna jména zítřejšího dne
+{{ states('sensor.nameday_tomorrow') }}
+
+# Jen první jméno
+{{ state_attr('sensor.nameday_tomorrow', 'names')[0] }}
+```
 
 ### Příklad automatizace: narozeniny 3 dny dopředu
 ```yaml

--- a/custom_components/cz_sk_calendar/core/__init__.py
+++ b/custom_components/cz_sk_calendar/core/__init__.py
@@ -19,6 +19,7 @@ from .data_sources import (
     get_special_day_name,
     get_next_special_day,
     get_nameday,
+    get_nameday_names,
     get_namedays_in_week,
 )
 from .cache import cached_date, clear_cache
@@ -44,6 +45,7 @@ __all__ = [
     "get_special_day_name",
     "get_next_special_day",
     "get_nameday",
+    "get_nameday_names",
     "get_namedays_in_week",
     # Cache
     "cached_date",

--- a/custom_components/cz_sk_calendar/core/data_sources.py
+++ b/custom_components/cz_sk_calendar/core/data_sources.py
@@ -90,9 +90,19 @@ def _get_holidays_raw(year: int, country: str) -> dict[date, str]:
 
 
 @lru_cache(maxsize=32)
+def _get_holidays_cached(year: int, country: str) -> tuple[tuple[date, str], ...]:
+    """Cache holidays as an immutable tuple of (date, name) pairs."""
+    return tuple(sorted(_get_holidays_raw(year, country).items()))
+
+
 def get_all_holidays(year: int, country: str) -> dict[date, str]:
-    """Get all holidays for a given year and country."""
-    return _get_holidays_raw(year, country)
+    """Get all holidays for a given year and country.
+
+    A fresh dict is returned on every call. Several callers merge multiple
+    years into the returned value, which would otherwise grow the cached
+    entry on every update.
+    """
+    return dict(_get_holidays_cached(year, country))
 
 
 def get_holiday_name(check_date: date, country: str) -> Optional[str]:
@@ -136,11 +146,25 @@ def _get_vacations_raw(
 
 
 @lru_cache(maxsize=32)
+def _get_vacations_cached(
+    school_year: int, country: str, region: str
+) -> tuple[tuple[date, date, str], ...]:
+    """Cache vacations as an immutable tuple, sorted by start date."""
+    return tuple(
+        sorted(_get_vacations_raw(school_year, country, region), key=lambda x: x[0])
+    )
+
+
 def get_all_vacations(
     school_year: int, country: str, region: str
 ) -> list[tuple[date, date, str]]:
-    """Get all school vacations for a school year."""
-    return _get_vacations_raw(school_year, country, region)
+    """Get all school vacations for a school year.
+
+    A fresh list is returned on every call. Several callers extend the
+    returned value with another school year, which would otherwise append to
+    the cached entry over and over on every update.
+    """
+    return list(_get_vacations_cached(school_year, country, region))
 
 
 def get_vacation_name(check_date: date, country: str, region: str) -> Optional[str]:
@@ -233,11 +257,21 @@ def _get_special_days_sk(year: int) -> dict[date, str]:
 
 
 @lru_cache(maxsize=16)
-def get_all_special_days(year: int, country: str) -> dict[date, str]:
-    """Get all special days for a given year and country."""
+def _get_special_days_cached(year: int, country: str) -> tuple[tuple[date, str], ...]:
+    """Cache special days as an immutable tuple of (date, name) pairs."""
     if country == COUNTRY_CZ:
-        return _get_special_days_cz(year)
-    return _get_special_days_sk(year)
+        special_days = _get_special_days_cz(year)
+    else:
+        special_days = _get_special_days_sk(year)
+    return tuple(sorted(special_days.items()))
+
+
+def get_all_special_days(year: int, country: str) -> dict[date, str]:
+    """Get all special days for a given year and country.
+
+    A fresh dict is returned on every call so callers may mutate it safely.
+    """
+    return dict(_get_special_days_cached(year, country))
 
 
 def get_special_day_name(check_date: date, country: str) -> Optional[str]:
@@ -363,13 +397,15 @@ _NAMEDAYS_CZ: dict[tuple[int, int], str] = {
     (12, 28): "Bohumila", (12, 29): "Judita", (12, 30): "David", (12, 31): "Silvestr",
 }
 
-# Slovak name days - official Slovak calendar
+# Slovak name days - official Slovak calendar.
+# Days with more than one name list them all, comma separated
+# (e.g. 2. 9. is "Linda, Rebeka"), matching the published Slovak calendar.
 _NAMEDAYS_SK: dict[tuple[int, int], str] = {
-    (1, 1): "Nový rok", (1, 2): "Alexandra", (1, 3): "Daniela", (1, 4): "Drahoslav",
-    (1, 5): "Andrea", (1, 6): "Traja králi", (1, 7): "Bohuslava", (1, 8): "Severín",
+    (1, 1): "Nový rok", (1, 2): "Alexandra, Karina", (1, 3): "Daniela", (1, 4): "Drahoslav",
+    (1, 5): "Andrea", (1, 6): "Antónia", (1, 7): "Bohuslava", (1, 8): "Severín",
     (1, 9): "Alexej", (1, 10): "Dáša", (1, 11): "Malvína", (1, 12): "Ernest",
-    (1, 13): "Rastislav", (1, 14): "Radovan", (1, 15): "Dobroslav", (1, 16): "Kristína",
-    (1, 17): "Nataša", (1, 18): "Bohdana", (1, 19): "Drahomíra", (1, 20): "Dalibor",
+    (1, 13): "Rastislav", (1, 14): "Radovan", (1, 15): "Dobroslav, Dobroslava", (1, 16): "Kristína",
+    (1, 17): "Nataša", (1, 18): "Bohdana", (1, 19): "Drahomíra, Mário", (1, 20): "Dalibor",
     (1, 21): "Vincent", (1, 22): "Zora", (1, 23): "Miloš", (1, 24): "Timotej",
     (1, 25): "Gejza", (1, 26): "Tamara", (1, 27): "Bohuš", (1, 28): "Alfonz",
     (1, 29): "Gašpar", (1, 30): "Ema", (1, 31): "Emil",
@@ -382,25 +418,25 @@ _NAMEDAYS_SK: dict[tuple[int, int], str] = {
     (2, 25): "Frederik, Frederika", (2, 26): "Viktor", (2, 27): "Alexander",
     (2, 28): "Zlatica", (2, 29): "Radomír",
     (3, 1): "Albín", (3, 2): "Anežka", (3, 3): "Bohumil, Bohumila", (3, 4): "Kazimír",
-    (3, 5): "Fridrich", (3, 6): "Radoslav", (3, 7): "Tomáš", (3, 8): "Alan, Alana",
+    (3, 5): "Fridrich", (3, 6): "Radoslav, Radoslava", (3, 7): "Tomáš", (3, 8): "Alan, Alana",
     (3, 9): "Františka", (3, 10): "Branislav, Bruno", (3, 11): "Angela, Angelika",
     (3, 12): "Gregor", (3, 13): "Vlastimil", (3, 14): "Matilda", (3, 15): "Svetlana",
     (3, 16): "Boleslav", (3, 17): "Ľubica", (3, 18): "Eduard", (3, 19): "Jozef",
     (3, 20): "Víťazoslav", (3, 21): "Blahoslav", (3, 22): "Beňadik", (3, 23): "Adrián",
     (3, 24): "Gabriel", (3, 25): "Marián", (3, 26): "Emanuel", (3, 27): "Alena",
-    (3, 28): "Soňa", (3, 29): "Miroslav", (3, 30): "Vieroslav", (3, 31): "Benjamín",
+    (3, 28): "Soňa", (3, 29): "Miroslav", (3, 30): "Vieroslava", (3, 31): "Benjamín",
     (4, 1): "Hugo", (4, 2): "Zita", (4, 3): "Richard", (4, 4): "Izidor",
     (4, 5): "Miroslava", (4, 6): "Irena", (4, 7): "Zoltán", (4, 8): "Albert",
     (4, 9): "Milena", (4, 10): "Igor", (4, 11): "Július", (4, 12): "Estera",
     (4, 13): "Aleš", (4, 14): "Justína", (4, 15): "Fedor", (4, 16): "Dana, Danica",
-    (4, 17): "Rudolf", (4, 18): "Valér", (4, 19): "Jela", (4, 20): "Marcel",
+    (4, 17): "Rudolf, Rudolfa", (4, 18): "Valér", (4, 19): "Jela", (4, 20): "Marcel",
     (4, 21): "Ervín", (4, 22): "Slavomír", (4, 23): "Vojtech", (4, 24): "Juraj",
     (4, 25): "Marek", (4, 26): "Jaroslava", (4, 27): "Jaroslav", (4, 28): "Jarmila",
     (4, 29): "Lea", (4, 30): "Anastázia",
     (5, 1): "Sviatok práce", (5, 2): "Žigmund", (5, 3): "Galina, Timea", (5, 4): "Florián",
-    (5, 5): "Lesana", (5, 6): "Hermína", (5, 7): "Monika", (5, 8): "Ingrida",
+    (5, 5): "Lesana, Lesia", (5, 6): "Hermína", (5, 7): "Monika", (5, 8): "Ingrida",
     (5, 9): "Roland", (5, 10): "Viktória", (5, 11): "Blažena", (5, 12): "Pankrác",
-    (5, 13): "Servác", (5, 14): "Bonifác", (5, 15): "Žofia", (5, 16): "Svetozár",
+    (5, 13): "Servác", (5, 14): "Bonifác", (5, 15): "Žofia, Sofia", (5, 16): "Svetozár",
     (5, 17): "Gizela", (5, 18): "Viola", (5, 19): "Gertrúda", (5, 20): "Bernard",
     (5, 21): "Zina", (5, 22): "Júlia, Juliana", (5, 23): "Želmíra", (5, 24): "Ela",
     (5, 25): "Urban", (5, 26): "Dušan", (5, 27): "Iveta", (5, 28): "Viliam",
@@ -408,34 +444,34 @@ _NAMEDAYS_SK: dict[tuple[int, int], str] = {
     (6, 1): "Žaneta", (6, 2): "Xénia, Oxana", (6, 3): "Karolína", (6, 4): "Lenka",
     (6, 5): "Laura", (6, 6): "Norbert", (6, 7): "Róbert", (6, 8): "Medard",
     (6, 9): "Stanislava", (6, 10): "Margaréta", (6, 11): "Dobroslava", (6, 12): "Zlatko",
-    (6, 13): "Anton", (6, 14): "Vasil", (6, 15): "Vít", (6, 16): "Blanka",
+    (6, 13): "Anton", (6, 14): "Vasil", (6, 15): "Vít", (6, 16): "Blanka, Bianka",
     (6, 17): "Adolf", (6, 18): "Vratislav", (6, 19): "Alfréd", (6, 20): "Valéria",
     (6, 21): "Alojz", (6, 22): "Paulína", (6, 23): "Sidónia", (6, 24): "Ján",
-    (6, 25): "Tadeáš", (6, 26): "Adriána", (6, 27): "Ladislav", (6, 28): "Beáta",
+    (6, 25): "Tadeáš, Olívia", (6, 26): "Adriána", (6, 27): "Ladislav, Ladislava", (6, 28): "Beáta",
     (6, 29): "Peter, Pavol, Petra", (6, 30): "Melánia",
     (7, 1): "Diana", (7, 2): "Berta", (7, 3): "Miloslav", (7, 4): "Prokop",
-    (7, 5): "Cyril, Metod", (7, 6): "Patrícia", (7, 7): "Oliver", (7, 8): "Ivan",
+    (7, 5): "Cyril, Metod", (7, 6): "Patrik, Patrícia", (7, 7): "Oliver", (7, 8): "Ivan",
     (7, 9): "Lujza", (7, 10): "Amália", (7, 11): "Milota", (7, 12): "Nina",
     (7, 13): "Margita", (7, 14): "Kamil", (7, 15): "Henrich", (7, 16): "Drahomír",
     (7, 17): "Bohuslav", (7, 18): "Kamila", (7, 19): "Dušana", (7, 20): "Iľja, Eliáš",
     (7, 21): "Daniel", (7, 22): "Magdaléna", (7, 23): "Oľga", (7, 24): "Vladimír",
-    (7, 25): "Jakub", (7, 26): "Anna, Hana", (7, 27): "Božena", (7, 28): "Krištof",
+    (7, 25): "Jakub, Timur", (7, 26): "Anna, Hana", (7, 27): "Božena", (7, 28): "Krištof",
     (7, 29): "Marta", (7, 30): "Libuša", (7, 31): "Ignác",
-    (8, 1): "Božidara", (8, 2): "Gustav", (8, 3): "Jerguš", (8, 4): "Dominik, Dominika",
+    (8, 1): "Božidara", (8, 2): "Gustáv", (8, 3): "Jerguš", (8, 4): "Dominik, Dominika",
     (8, 5): "Hortenzia", (8, 6): "Jozefína", (8, 7): "Štefánia", (8, 8): "Oskar",
     (8, 9): "Ľubomíra", (8, 10): "Vavrinec", (8, 11): "Zuzana", (8, 12): "Darina",
     (8, 13): "Ľubomír", (8, 14): "Mojmír", (8, 15): "Marcela", (8, 16): "Leonard",
-    (8, 17): "Milica", (8, 18): "Elena, Helena", (8, 19): "Lýdia", (8, 20): "Anabela",
+    (8, 17): "Milica", (8, 18): "Elena, Helena", (8, 19): "Lýdia", (8, 20): "Anabela, Liliana",
     (8, 21): "Jana", (8, 22): "Tichomír", (8, 23): "Filip", (8, 24): "Bartolomej",
     (8, 25): "Ľudovít", (8, 26): "Samuel", (8, 27): "Silvia", (8, 28): "Augustín",
     (8, 29): "Nikola, Nikolaj", (8, 30): "Ružena", (8, 31): "Nora",
-    (9, 1): "Drahoslava", (9, 2): "Linda", (9, 3): "Belo", (9, 4): "Rozália",
+    (9, 1): "Drahoslava", (9, 2): "Linda, Rebeka", (9, 3): "Belo", (9, 4): "Rozália",
     (9, 5): "Regina", (9, 6): "Alica", (9, 7): "Marianna", (9, 8): "Miriama",
     (9, 9): "Martina", (9, 10): "Oleg", (9, 11): "Bystrík", (9, 12): "Mária",
     (9, 13): "Ctibor", (9, 14): "Ľudomil", (9, 15): "Jolana", (9, 16): "Ľudmila",
     (9, 17): "Olympia", (9, 18): "Eugénia", (9, 19): "Konštantín", (9, 20): "Ľuboslav, Ľuboslava",
-    (9, 21): "Matúš", (9, 22): "Móric", (9, 23): "Zdenka", (9, 24): "Ľuboš",
-    (9, 25): "Vladislav", (9, 26): "Edita", (9, 27): "Cyprián", (9, 28): "Václav",
+    (9, 21): "Matúš", (9, 22): "Móric", (9, 23): "Zdenka", (9, 24): "Ľuboš, Ľubor",
+    (9, 25): "Vladislav, Vladislava", (9, 26): "Edita", (9, 27): "Cyprián", (9, 28): "Václav",
     (9, 29): "Michal, Michaela", (9, 30): "Jarolím",
     (10, 1): "Arnold", (10, 2): "Levoslav", (10, 3): "Stela", (10, 4): "František",
     (10, 5): "Viera", (10, 6): "Natália", (10, 7): "Eliška", (10, 8): "Brigita",
@@ -444,7 +480,7 @@ _NAMEDAYS_SK: dict[tuple[int, int], str] = {
     (10, 17): "Hedviga", (10, 18): "Lukáš", (10, 19): "Kristián", (10, 20): "Vendelín",
     (10, 21): "Uršuľa", (10, 22): "Sergej", (10, 23): "Alojzia", (10, 24): "Kvetoslava",
     (10, 25): "Aurel", (10, 26): "Demeter", (10, 27): "Sabína", (10, 28): "Dobromila",
-    (10, 29): "Klára", (10, 30): "Šimon, Šimona", (10, 31): "Aurélia",
+    (10, 29): "Klára", (10, 30): "Šimon, Simona", (10, 31): "Aurélia",
     (11, 1): "Denis, Denisa", (11, 2): "Pamiatka zosnulých", (11, 3): "Hubert",
     (11, 4): "Karol", (11, 5): "Imrich", (11, 6): "Renáta", (11, 7): "René",
     (11, 8): "Bohumír", (11, 9): "Teodor", (11, 10): "Tibor", (11, 11): "Martin, Maroš",
@@ -453,14 +489,14 @@ _NAMEDAYS_SK: dict[tuple[int, int], str] = {
     (11, 20): "Félix", (11, 21): "Elvíra", (11, 22): "Cecília", (11, 23): "Klement",
     (11, 24): "Emília", (11, 25): "Katarína", (11, 26): "Kornel", (11, 27): "Milan",
     (11, 28): "Henrieta", (11, 29): "Vratko", (11, 30): "Ondrej, Andrej",
-    (12, 1): "Edmund", (12, 2): "Bibiána", (12, 3): "Oldrich", (12, 4): "Barbora",
+    (12, 1): "Edmund", (12, 2): "Bibiána", (12, 3): "Oldrich", (12, 4): "Barbora, Barbara",
     (12, 5): "Oto", (12, 6): "Mikuláš", (12, 7): "Ambróz", (12, 8): "Marína",
     (12, 9): "Izabela", (12, 10): "Radúz", (12, 11): "Hilda", (12, 12): "Otília",
     (12, 13): "Lucia", (12, 14): "Branislava, Bronislava", (12, 15): "Ivica",
     (12, 16): "Albína", (12, 17): "Kornélia", (12, 18): "Sláva, Slávka", (12, 19): "Judita",
     (12, 20): "Dagmara", (12, 21): "Bohdan", (12, 22): "Adela", (12, 23): "Nadežda",
     (12, 24): "Adam, Eva", (12, 25): "1. sviatok vianočný", (12, 26): "Štefan",
-    (12, 27): "Filoména", (12, 28): "Ivana", (12, 29): "Milada", (12, 30): "Dávid",
+    (12, 27): "Filoména", (12, 28): "Ivana, Ivona", (12, 29): "Milada", (12, 30): "Dávid",
     (12, 31): "Silvester",
 }
 
@@ -470,6 +506,26 @@ def get_nameday(check_date: date, country: str) -> Optional[str]:
     key = (check_date.month, check_date.day)
     namedays = _NAMEDAYS_CZ if country == COUNTRY_CZ else _NAMEDAYS_SK
     return namedays.get(key)
+
+
+def get_nameday_names(check_date: date, country: str) -> list[str]:
+    """Get all names celebrating their name day on a given date.
+
+    The Slovak calendar in particular has several days shared by two or more
+    names (2. 9. is "Linda, Rebeka"), so return them as a list rather than a
+    single string.
+
+    Args:
+        check_date: Date to check
+        country: Country code (CZ or SK)
+
+    Returns:
+        List of names, empty when the date carries no name
+    """
+    nameday = get_nameday(check_date, country)
+    if not nameday:
+        return []
+    return [name.strip() for name in nameday.split(",") if name.strip()]
 
 
 def get_namedays_in_week(from_date: date, country: str) -> dict[date, str]:

--- a/custom_components/cz_sk_calendar/sensor.py
+++ b/custom_components/cz_sk_calendar/sensor.py
@@ -27,6 +27,7 @@ from .core import (
     get_all_vacations,
     get_holiday_name,
     get_nameday,
+    get_nameday_names,
     get_namedays_in_week,
     get_next_holiday,
     get_next_vacation,
@@ -250,12 +251,10 @@ async def async_setup_entry(
             "mdi:star",
             lambda e: get_special_day_name(e.today, e._country),
         ),
-        CZSKNameSensor(
-            config_entry, "nameday",
-            "Jmeniny" if country == COUNTRY_CZ else "Meniny",
-            "mdi:cake-variant",
-            lambda e: get_nameday(e.today, e._country),
-        ),
+        # Name day sensors (today / tomorrow / day after tomorrow)
+        CZSKNamedaySensor(config_entry, country, 0),
+        CZSKNamedaySensor(config_entry, country, 1),
+        CZSKNamedaySensor(config_entry, country, 2),
         # Next event sensors
         CZSKNextHolidaySensor(config_entry, country),
         CZSKNextVacationSensor(config_entry, country, region),
@@ -611,6 +610,66 @@ _CZ_DAY_NAMES = [
 _SK_DAY_NAMES = [
     "Pondelok", "Utorok", "Streda", "Štvrtok", "Piatok", "Sobota", "Nedeľa"
 ]
+
+
+class CZSKNamedaySensor(CZSKBaseSensor):
+    """Sensor for the name day of today, tomorrow or the day after tomorrow.
+
+    The state is the full calendar entry for that day. Days shared by more
+    than one name (the Slovak calendar has plenty, e.g. 2. 9. "Linda,
+    Rebeka") keep every name in the state and also expose them one by one in
+    the ``names`` attribute.
+    """
+
+    # offset in days -> (entity_type, Czech name, Slovak name, icon)
+    _VARIANTS: dict[int, tuple[str, str, str, str]] = {
+        0: ("nameday", "Jmeniny", "Meniny", "mdi:cake-variant"),
+        1: ("nameday_tomorrow", "Jmeniny zítra", "Meniny zajtra", "mdi:cake"),
+        2: (
+            "nameday_day_after_tomorrow",
+            "Jmeniny pozítří",
+            "Meniny pozajtra",
+            "mdi:cake-layered",
+        ),
+    }
+
+    def __init__(
+        self, config_entry: ConfigEntry, country: str, offset: int = 0
+    ) -> None:
+        """Initialize the name day sensor.
+
+        Args:
+            config_entry: The config entry
+            country: Country code (CZ or SK)
+            offset: Days from today (0 = today, 1 = tomorrow, 2 = day after)
+        """
+        entity_type, cz_name, sk_name, icon = self._VARIANTS[offset]
+        name = cz_name if country == COUNTRY_CZ else sk_name
+        super().__init__(config_entry, entity_type, name, icon)
+        self._offset = offset
+
+    @property
+    def _target_date(self) -> date:
+        """Date this sensor reports on."""
+        return self.today + timedelta(days=self._offset)
+
+    @property
+    def native_value(self) -> str | None:
+        """Return all names of the day, comma separated."""
+        return get_nameday(self._target_date, self._country)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional attributes."""
+        attrs = super().extra_state_attributes.copy()
+        target = self._target_date
+        names = get_nameday_names(target, self._country)
+
+        attrs["date"] = target.isoformat()
+        attrs["offset_days"] = self._offset
+        attrs["names"] = names
+        attrs["names_count"] = len(names)
+        return attrs
 
 
 class CZSKTodayDayNameSensor(CZSKBaseSensor):


### PR DESCRIPTION
Atribut `vacations` u senzoru školního roku narůstal donekonečna a opakoval stejné prázdniny. `get_all_vacations()` je pod `@lru_cache` a vracela přímo uloženou instanci seznamu; calendar.py na ni volal `.extend()` s dalším školním rokem, takže se do cache při každé aktualizaci přidalo dalších šest záznamů. Stejný problém měly `get_all_holidays()` / `get_all_special_days()`, kde volající volali `.update()`.

Cachují se teď neměnné tuple a veřejné funkce vracejí při každém volání novou kopii, takže volající mohou s výsledkem dál pracovat jako doposud.

Slovenský kalendář má na řadě dní víc jmen, v tabulce ale bylo jen jedno (2. 9. „Linda“ místo „Linda, Rebeka“). Doplněno 22 dní podle slovenského kalendáře, včetně 6. 1. „Antónia“ (dosud tam byl název svátku) a opravy
30. 3. „Vieroslava“, 30. 10. „Simona“ a 2. 8. „Gustáv“.

Nové senzory `sensor.nameday_tomorrow` a
`sensor.nameday_day_after_tomorrow`; dnešní `sensor.nameday` se používá dál pod stejným unique_id. Všechny tři mají ve stavu všechna jména dne oddělená čárkou a v atributech `names` (seznam), `names_count`, `date` a `offset_days`.


Claude-Session: https://claude.ai/code/session_01VXQb34Ck22eapaYRKbYXct