### PR TITLE
Přidat kalendář jmenin/menin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ obsahuje všechna, oddělená čárkou. Jednotlivá jména najdete i v atributec
 | `date` | Datum, ke kterému se senzor vztahuje |
 | `offset_days` | 0 = dnes, 1 = zítra, 2 = pozítří |
 
+Kromě senzorů jsou jmeniny dostupné i jako samostatný kalendář
+(`calendar.jmeniny`, na Slovensku „Meniny“) – obsahuje událost pro každý den
+v roce s názvem daného dne. Kombinovaný kalendář svátků a prázdnin zůstává beze
+změny, aby ho jmeniny nezaplnily.
+
 ```yaml
 # Všechna jména zítřejšího dne
 {{ states('sensor.nameday_tomorrow') }}
@@ -178,6 +183,7 @@ automation:
 | `calendar.skolni_prazdniny` | Pouze školní prázdniny |
 | `calendar.svatky_a_prazdniny` | Kombinovaný kalendář |
 | `calendar.vlastni_udalosti` | Narozeniny a rodinné svátky |
+| `calendar.jmeniny` | Jmeniny / meniny – událost na každý den v roce |
 
 ## Příklady automatizací
 

--- a/custom_components/cz_sk_calendar/calendar.py
+++ b/custom_components/cz_sk_calendar/calendar.py
@@ -26,6 +26,7 @@ from .core import (
     get_all_holidays,
     get_all_vacations,
     get_holiday_name,
+    get_nameday,
     get_school_year,
     get_vacation_name,
     is_holiday,
@@ -50,6 +51,7 @@ async def async_setup_entry(
         CZSKVacationCalendar(config_entry, country, region),
         CZSKCombinedCalendar(config_entry, country, region),
         CZSKCustomEventsCalendar(config_entry, country, region),
+        CZSKNamedayCalendar(config_entry, country, region),
     ]
 
     async_add_entities(calendars, True)
@@ -494,6 +496,61 @@ class CZSKCustomEventsCalendar(CZSKBaseCalendar):
                         start=current,
                         end=current + timedelta(days=1),
                         summary=name,
+                    )
+                )
+            current += timedelta(days=1)
+
+        return events
+
+
+class CZSKNamedayCalendar(CZSKBaseCalendar):
+    """Calendar for name days (jmeniny / meniny)."""
+
+    def __init__(
+        self, config_entry: ConfigEntry, country: str, region: str
+    ) -> None:
+        """Initialize the nameday calendar."""
+        name = "Jmeniny" if country == COUNTRY_CZ else "Meniny"
+        super().__init__(config_entry, country, region, "namedays", name)
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return today's nameday, or the next day that carries one."""
+        today = date.today()
+
+        for offset in range(366):
+            current = today + timedelta(days=offset)
+            nameday = get_nameday(current, self._country)
+            if nameday:
+                return CalendarEvent(
+                    start=current,
+                    end=current + timedelta(days=1),
+                    summary=nameday,
+                )
+
+        return None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        """Return calendar events within a datetime range."""
+        events = []
+
+        start = start_date.date() if isinstance(start_date, datetime) else start_date
+        end = end_date.date() if isinstance(end_date, datetime) else end_date
+
+        current = start
+        while current <= end:
+            nameday = get_nameday(current, self._country)
+            if nameday:
+                events.append(
+                    CalendarEvent(
+                        start=current,
+                        end=current + timedelta(days=1),
+                        summary=nameday,
                     )
                 )
             current += timedelta(days=1)


### PR DESCRIPTION
Integrace dosud vytvářela čtyři kalendáře (svátky, prázdniny, kombinovaný a vlastní události); jmeniny byly dostupné jen jako senzory. Přidává samostatnou entitu calendar.jmeniny / calendar.meniny s událostí na každý den v roce. Ostatní kalendáře zůstávají beze změny, kombinovaný kalendář jmeniny nezahrnuje, aby ho denní události nezaplnily.


Claude-Session: https://claude.ai/code/session_014XtTGTXbZUMNH6KUQmd6hW