### PR TITLE
Opravit options flow, ID entit a nesrovnalosti v dokumentaci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.Python
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Tooling / test caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Editors
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -104,7 +104,14 @@ V možnostech integrace nastavíte:
 
 ## Vytvořené entity
 
-### Senzory (binary_sensor pattern)
+> **Pozn. k ID entit:** zobrazovaná jména jsou česká/slovenská podle zvolené
+> země, ale `entity_id` je záměrně anglické a stejné pro CZ i SK – jinak by
+> každá instalace měla jiná ID. Pokud jste integraci používali před verzí
+> 1.1.0, vaše entity si ponechají původní ID odvozená z názvu
+> (např. `sensor.pracovni_den`); přejmenovat je můžete v *Nastavení →
+> Zařízení a služby → Entity*.
+
+### Senzory
 
 | Senzor | Popis | Hodnota |
 |--------|-------|---------|
@@ -128,6 +135,29 @@ V možnostech integrace nastavíte:
 | `sensor.nameday` | Jmeniny / meniny dneška | text nebo `None` |
 | `sensor.nameday_tomorrow` | Jmeniny / meniny zítřka | text nebo `None` |
 | `sensor.nameday_day_after_tomorrow` | Jmeniny / meniny pozítřka | text nebo `None` |
+| `sensor.today_day_name` | Název dnešního dne v týdnu | text |
+| `sensor.tomorrow_day_name` | Název zítřejšího dne v týdnu | text |
+| `sensor.today_birthday` | Dnešní narozeniny | text nebo `None` |
+| `sensor.today_family_holiday` | Dnešní rodinný svátek | text nebo `None` |
+| `sensor.workdays_to_weekend` | Pracovních dní do víkendu | číslo |
+| `sensor.school_year` | Aktuální školní rok | text, např. `2026/2027` |
+| `sensor.workdays_in_month` | Počet pracovních dní v měsíci | číslo |
+| `sensor.school_days_in_month` | Počet školních dní v měsíci | číslo |
+| `sensor.vacation_remaining` | Zbývá dní aktuálních prázdnin | číslo |
+
+### Binární senzory
+
+Stejné informace jsou dostupné i jako `binary_sensor` s hodnotami `on` / `off`,
+což se lépe používá v podmínkách automatizací:
+
+| Entita | Popis |
+|--------|-------|
+| `binary_sensor.workday` | Je dnes pracovní den? |
+| `binary_sensor.school_day` | Je dnes školní den? |
+| `binary_sensor.holiday` | Je dnes svátek? |
+| `binary_sensor.vacation` | Jsou dnes prázdniny? |
+| `binary_sensor.weekend` | Je dnes víkend? |
+| `binary_sensor.special_day` | Je dnes významný den? |
 
 ### Jmeniny / meniny
 
@@ -143,7 +173,7 @@ obsahuje všechna, oddělená čárkou. Jednotlivá jména najdete i v atributec
 | `offset_days` | 0 = dnes, 1 = zítra, 2 = pozítří |
 
 Kromě senzorů jsou jmeniny dostupné i jako samostatný kalendář
-(`calendar.jmeniny`, na Slovensku „Meniny“) – obsahuje událost pro každý den
+(`calendar.namedays`, zobrazený jako „Jmeniny“ / „Meniny“) – obsahuje událost pro každý den
 v roce s názvem daného dne. Kombinovaný kalendář svátků a prázdnin zůstává beze
 změny, aby ho jmeniny nezaplnily.
 
@@ -207,11 +237,11 @@ automation:
 
 | Kalendář | Popis |
 |----------|-------|
-| `calendar.svatky` | Pouze státní svátky |
-| `calendar.skolni_prazdniny` | Pouze školní prázdniny |
-| `calendar.svatky_a_prazdniny` | Kombinovaný kalendář |
-| `calendar.vlastni_udalosti` | Narozeniny a rodinné svátky |
-| `calendar.jmeniny` | Jmeniny / meniny – událost na každý den v roce |
+| `calendar.holidays` | Pouze státní svátky |
+| `calendar.vacations` | Pouze školní prázdniny |
+| `calendar.combined` | Kombinovaný kalendář |
+| `calendar.custom_events` | Narozeniny a rodinné svátky |
+| `calendar.namedays` | Jmeniny / meniny – událost na každý den v roce |
 
 ## Příklady automatizací
 
@@ -224,8 +254,8 @@ automation:
         at: "06:30:00"
     condition:
       - condition: state
-        entity_id: sensor.cz_sk_calendar_school_day
-        state: "True"
+        entity_id: binary_sensor.school_day
+        state: "on"
     action:
       - service: media_player.play_media
         target:
@@ -241,15 +271,15 @@ automation:
   - alias: "Oznámení o prázdninách"
     trigger:
       - platform: numeric_state
-        entity_id: sensor.cz_sk_calendar_days_to_vacation
+        entity_id: sensor.days_to_vacation
         below: 8
     action:
       - service: notify.mobile_app
         data:
           title: "Prázdniny se blíží!"
           message: >
-            Za {{ states('sensor.cz_sk_calendar_days_to_vacation') }} dní začínají
-            {{ state_attr('sensor.cz_sk_calendar_next_vacation', 'friendly_name') }}
+            Za {{ states('sensor.days_to_vacation') }} dní začínají
+            {{ state_attr('sensor.next_vacation', 'friendly_name') }}
 ```
 
 ### Jiný režim topení o prázdninách
@@ -258,8 +288,8 @@ automation:
   - alias: "Prázdninový režim topení"
     trigger:
       - platform: state
-        entity_id: sensor.cz_sk_calendar_vacation
-        to: "True"
+        entity_id: binary_sensor.vacation
+        to: "on"
     action:
       - service: climate.set_preset_mode
         target:

--- a/custom_components/cz_sk_calendar/__init__.py
+++ b/custom_components/cz_sk_calendar/__init__.py
@@ -19,6 +19,10 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.CALENDAR]
 
+# The integration is configured through the UI only; declaring this keeps
+# Home Assistant from warning about a missing config schema.
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 SERVICE_GET_NAMEDAY = "get_nameday"
 
 _GET_NAMEDAY_SCHEMA = vol.Schema(

--- a/custom_components/cz_sk_calendar/binary_sensor.py
+++ b/custom_components/cz_sk_calendar/binary_sensor.py
@@ -12,8 +12,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_COUNTRY, CONF_REGION, COUNTRY_CZ
-from .entity import CZSKEntity
+from .const import COUNTRY_CZ
+from .entity import CZSKEntity, get_configured_country
 from .core import (
     get_holiday_name,
     get_special_day_name,
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the CZ/SK Calendar binary sensors."""
-    country = config_entry.data[CONF_COUNTRY]
+    country = get_configured_country(config_entry)
 
     sensors = [
         CZSKBinarySensor(
@@ -41,7 +41,6 @@ async def async_setup_entry(
             "mdi:briefcase",
             "mdi:briefcase-off",
             lambda e: is_workday(e.today, e._country),
-            BinarySensorDeviceClass.OCCUPANCY,
         ),
         CZSKBinarySensor(
             config_entry,

--- a/custom_components/cz_sk_calendar/calendar.py
+++ b/custom_components/cz_sk_calendar/calendar.py
@@ -1,9 +1,8 @@
 """Calendar platform for CZ/SK School & Work Calendar."""
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 import logging
-from typing import Any
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
@@ -12,8 +11,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    CONF_COUNTRY,
-    CONF_REGION,
     CONF_CUSTOM_BIRTHDAYS,
     CONF_CUSTOM_HOLIDAYS,
     CONF_CUSTOM_EVENTS,
@@ -29,9 +26,8 @@ from .core import (
     get_nameday,
     get_school_year,
     get_vacation_name,
-    is_holiday,
-    is_vacation,
 )
+from .entity import get_configured_country, get_configured_region
 from .sensor import _parse_custom_list, _get_custom_event_name, _get_next_custom_event
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,8 +39,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the CZ/SK Calendar entities."""
-    country = config_entry.data[CONF_COUNTRY]
-    region = config_entry.data[CONF_REGION]
+    country = get_configured_country(config_entry)
+    region = get_configured_region(config_entry)
 
     calendars = [
         CZSKHolidayCalendar(config_entry, country, region),
@@ -60,7 +56,10 @@ async def async_setup_entry(
 class CZSKBaseCalendar(CalendarEntity):
     """Base class for CZ/SK Calendar entities."""
 
-    _attr_has_entity_name = True
+    # Kept in sync with CZSKEntity: with has_entity_name enabled Home Assistant
+    # prefixes the object id with the device name, which would produce ids like
+    # calendar.cz_sk_calendar_ceska_republika_praha_1_5_svatky.
+    _attr_has_entity_name = False
 
     def __init__(
         self,
@@ -76,7 +75,7 @@ class CZSKBaseCalendar(CalendarEntity):
         self._region = region
         self._calendar_type = calendar_type
 
-        region_name = (
+        self._region_name = (
             CZ_REGIONS.get(region, region)
             if country == COUNTRY_CZ
             else SK_REGIONS.get(region, region)
@@ -85,6 +84,16 @@ class CZSKBaseCalendar(CalendarEntity):
         self._attr_unique_id = f"{config_entry.entry_id}_{calendar_type}"
         self._attr_name = name
         self._event: CalendarEvent | None = None
+
+    @property
+    def suggested_object_id(self) -> str:
+        """Return a stable, language-independent object id.
+
+        See ``CZSKEntity.suggested_object_id`` - without this the id would be
+        built from the localized name and the device name, producing ids like
+        ``calendar.cz_sk_calendar_ceska_republika_praha_1_5_svatky``.
+        """
+        return self._calendar_type
 
     @property
     def device_info(self):
@@ -110,7 +119,7 @@ class CZSKHolidayCalendar(CZSKBaseCalendar):
     @property
     def event(self) -> CalendarEvent | None:
         """Return the current or next upcoming event."""
-        today = date.today()
+        today = dt_util.now().date()
         holiday_name = get_holiday_name(today, self._country)
 
         if holiday_name:
@@ -184,7 +193,7 @@ class CZSKVacationCalendar(CZSKBaseCalendar):
     @property
     def event(self) -> CalendarEvent | None:
         """Return the current or next upcoming event."""
-        today = date.today()
+        today = dt_util.now().date()
         vacation_name = get_vacation_name(today, self._country, self._region)
 
         if vacation_name:
@@ -272,7 +281,7 @@ class CZSKCombinedCalendar(CZSKBaseCalendar):
     @property
     def event(self) -> CalendarEvent | None:
         """Return the current or next upcoming event."""
-        today = date.today()
+        today = dt_util.now().date()
 
         # Check for holiday first
         holiday_name = get_holiday_name(today, self._country)
@@ -445,7 +454,7 @@ class CZSKCustomEventsCalendar(CZSKBaseCalendar):
     @property
     def event(self) -> CalendarEvent | None:
         """Return the current or next upcoming event."""
-        today = date.today()
+        today = dt_util.now().date()
         all_events = self._get_all_custom_events()
 
         if not all_events:
@@ -516,7 +525,7 @@ class CZSKNamedayCalendar(CZSKBaseCalendar):
     @property
     def event(self) -> CalendarEvent | None:
         """Return today's nameday, or the next day that carries one."""
-        today = date.today()
+        today = dt_util.now().date()
 
         for offset in range(366):
             current = today + timedelta(days=offset)

--- a/custom_components/cz_sk_calendar/config_flow.py
+++ b/custom_components/cz_sk_calendar/config_flow.py
@@ -5,13 +5,17 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.core import callback
 
 from .const import (
     CONF_COUNTRY,
     CONF_REGION,
-    CONF_CUSTOM_EVENTS,
     CONF_CUSTOM_BIRTHDAYS,
     CONF_CUSTOM_HOLIDAYS,
     CONF_REMINDER_DAYS,
@@ -95,17 +99,19 @@ class CZSKCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> CZSKCalendarOptionsFlow:
         """Get the options flow for this handler."""
-        return CZSKCalendarOptionsFlow(config_entry)
+        return CZSKCalendarOptionsFlow()
 
 
-class CZSKCalendarOptionsFlow(ConfigFlow):
-    """Handle options flow for CZ/SK Calendar."""
+class CZSKCalendarOptionsFlow(OptionsFlow):
+    """Handle options flow for CZ/SK Calendar.
 
-    def __init__(self, config_entry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
+    ``self.config_entry`` is provided by the options flow manager, so the
+    entry must not be passed in (and stored) by the flow itself.
+    """
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -116,7 +122,9 @@ class CZSKCalendarOptionsFlow(ConfigFlow):
 
         country = self.config_entry.data.get(CONF_COUNTRY, COUNTRY_CZ)
         regions = CZ_REGIONS if country == COUNTRY_CZ else SK_REGIONS
-        current_region = self.config_entry.data.get(CONF_REGION)
+        current_region = self.config_entry.options.get(
+            CONF_REGION, self.config_entry.data.get(CONF_REGION)
+        )
         current_birthdays = self.config_entry.options.get(CONF_CUSTOM_BIRTHDAYS, "")
         current_holidays = self.config_entry.options.get(CONF_CUSTOM_HOLIDAYS, "")
         current_reminder_days = self.config_entry.options.get(CONF_REMINDER_DAYS, 3)

--- a/custom_components/cz_sk_calendar/entity.py
+++ b/custom_components/cz_sk_calendar/entity.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_change
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_COUNTRY,
@@ -17,6 +18,27 @@ from .const import (
     SK_REGIONS,
     COUNTRY_CZ,
 )
+
+
+def get_configured_country(config_entry: ConfigEntry) -> str:
+    """Return the configured country for a config entry.
+
+    The country is chosen once during setup and cannot be changed later,
+    so it always lives in ``entry.data``.
+    """
+    return config_entry.data[CONF_COUNTRY]
+
+
+def get_configured_region(config_entry: ConfigEntry) -> str:
+    """Return the currently configured region for a config entry.
+
+    The region can be changed from the options flow, which stores it in
+    ``entry.options``. Fall back to the value picked during initial setup
+    for entries that were never reconfigured.
+    """
+    return config_entry.options.get(
+        CONF_REGION, config_entry.data[CONF_REGION]
+    )
 
 
 class CZSKEntity(Entity):
@@ -47,8 +69,8 @@ class CZSKEntity(Entity):
             icon: MDI icon name
         """
         self._config_entry = config_entry
-        self._country = config_entry.data[CONF_COUNTRY]
-        self._region = config_entry.data[CONF_REGION]
+        self._country = get_configured_country(config_entry)
+        self._region = get_configured_region(config_entry)
         self._entity_type = entity_type
 
         self._region_name = (
@@ -60,6 +82,18 @@ class CZSKEntity(Entity):
         self._attr_unique_id = f"{config_entry.entry_id}_{entity_type}"
         self._attr_name = name
         self._attr_icon = icon
+
+    @property
+    def suggested_object_id(self) -> str:
+        """Return a stable, language-independent object id.
+
+        Display names are localized (CZ/SK), so deriving the entity id from
+        the name would give Czech and Slovak installations different ids.
+        Basing it on the entity type keeps ``sensor.workday`` the same
+        everywhere and matches the entity table in the README. Only new
+        entities are affected; already registered ones keep their id.
+        """
+        return self._entity_type.removeprefix("binary_")
 
     @property
     def device_info(self) -> dict[str, Any]:
@@ -111,5 +145,5 @@ class CZSKEntity(Entity):
 
     @property
     def today(self) -> date:
-        """Get today's date (convenience property)."""
-        return date.today()
+        """Get today's date in Home Assistant's configured timezone."""
+        return dt_util.now().date()

--- a/custom_components/cz_sk_calendar/manifest.json
+++ b/custom_components/cz_sk_calendar/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/joshuaaaaa/HA---CZ-SK-Kalendar/issues",
   "requirements": [],
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/custom_components/cz_sk_calendar/sensor.py
+++ b/custom_components/cz_sk_calendar/sensor.py
@@ -12,8 +12,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
-    CONF_COUNTRY,
-    CONF_REGION,
     CONF_CUSTOM_EVENTS,
     CONF_CUSTOM_BIRTHDAYS,
     CONF_CUSTOM_HOLIDAYS,
@@ -21,14 +19,12 @@ from .const import (
     CONF_REMINDER_DAILY,
     COUNTRY_CZ,
 )
-from .entity import CZSKEntity
+from .entity import CZSKEntity, get_configured_country, get_configured_region
 from .core import (
-    get_all_holidays,
     get_all_vacations,
     get_holiday_name,
     get_nameday,
     get_nameday_names,
-    get_namedays_in_week,
     get_next_holiday,
     get_next_vacation,
     get_school_year,
@@ -203,8 +199,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the CZ/SK Calendar sensors."""
-    country = config_entry.data[CONF_COUNTRY]
-    region = config_entry.data[CONF_REGION]
+    country = get_configured_country(config_entry)
+    region = get_configured_region(config_entry)
 
     sensors = [
         # Boolean state sensors (kept for backwards compatibility)
@@ -258,9 +254,9 @@ async def async_setup_entry(
         # Next event sensors
         CZSKNextHolidaySensor(config_entry, country),
         CZSKNextVacationSensor(config_entry, country, region),
-    CZSKNextSpecialDaySensor(config_entry, country),
-    CZSKNextBirthdaySensor(config_entry, country),
-    CZSKNextFamilyHolidaySensor(config_entry, country),
+        CZSKNextSpecialDaySensor(config_entry, country),
+        CZSKNextBirthdaySensor(config_entry, country),
+        CZSKNextFamilyHolidaySensor(config_entry, country),
         # Day name sensors
         CZSKTodayDayNameSensor(config_entry, country),
         CZSKTomorrowDayNameSensor(config_entry, country),
@@ -270,9 +266,9 @@ async def async_setup_entry(
         # Countdown sensors
         CZSKDaysToHolidaySensor(config_entry, country),
         CZSKDaysToVacationSensor(config_entry, country, region),
-    CZSKDaysToSpecialDaySensor(config_entry, country),
-    CZSKDaysToBirthdaySensor(config_entry, country),
-    CZSKDaysToFamilyHolidaySensor(config_entry, country),
+        CZSKDaysToSpecialDaySensor(config_entry, country),
+        CZSKDaysToBirthdaySensor(config_entry, country),
+        CZSKDaysToFamilyHolidaySensor(config_entry, country),
         CZSKWorkdaysToWeekendSensor(config_entry, country),
         # School year sensor
         CZSKSchoolYearSensor(config_entry, country, region),

--- a/custom_components/cz_sk_calendar/translations/cs.json
+++ b/custom_components/cz_sk_calendar/translations/cs.json
@@ -30,87 +30,8 @@
           "custom_birthdays": "Vlastní narozeniny",
           "custom_holidays": "Vlastní svátky",
           "reminder_days": "Kolik dní předem připomínat",
-          "reminder_daily": "Připomínat denně v okně",
-          "custom_events": "Vlastní události (zastaralé)"
+          "reminder_daily": "Připomínat denně v okně"
         }
-      }
-    }
-  },
-  "entity": {
-    "sensor": {
-      "workday": {
-        "name": "Pracovní den"
-      },
-      "school_day": {
-        "name": "Školní den"
-      },
-      "holiday": {
-        "name": "Svátek"
-      },
-      "vacation": {
-        "name": "Prázdniny"
-      },
-      "holiday_name": {
-        "name": "Název svátku"
-      },
-      "special_day": {
-        "name": "Významný den"
-      },
-      "next_birthday": {
-        "name": "Příští narozeniny"
-      },
-      "days_to_birthday": {
-        "name": "Dní do narozenin"
-      },
-      "today_birthday": {
-        "name": "Dnešní narozeniny"
-      },
-      "next_family_holiday": {
-        "name": "Příští rodinný svátek"
-      },
-      "days_to_family_holiday": {
-        "name": "Dní do rodinného svátku"
-      },
-      "today_family_holiday": {
-        "name": "Dnešní rodinný svátek"
-      },
-      "vacation_name": {
-        "name": "Název prázdnin"
-      },
-      "next_holiday": {
-        "name": "Příští svátek"
-      },
-      "next_special_day": {
-        "name": "Příští významný den"
-      },
-      "next_vacation": {
-        "name": "Příští prázdniny"
-      },
-      "days_to_holiday": {
-        "name": "Dní do svátku"
-      },
-      "days_to_special_day": {
-        "name": "Dní do významného dne"
-      },
-      "days_to_vacation": {
-        "name": "Dní do prázdnin"
-      },
-      "today_day_name": {
-        "name": "Dnešní den"
-      },
-      "tomorrow_day_name": {
-        "name": "Zítřejší den"
-      }
-    },
-    "calendar": {
-      "holidays": {
-        "name": "Svátky"
-      },
-      "vacations": {
-        "name": "Školní prázdniny"
-      },
-      "combined": {
-        "name": "Svátky a prázdniny"
       }
     }
   },

--- a/custom_components/cz_sk_calendar/translations/en.json
+++ b/custom_components/cz_sk_calendar/translations/en.json
@@ -30,87 +30,8 @@
           "custom_birthdays": "Custom birthdays",
           "custom_holidays": "Custom holidays",
           "reminder_days": "Reminder days in advance",
-          "reminder_daily": "Notify daily in window",
-          "custom_events": "Custom events (legacy)"
+          "reminder_daily": "Notify daily in window"
         }
-      }
-    }
-  },
-  "entity": {
-    "sensor": {
-      "workday": {
-        "name": "Workday"
-      },
-      "school_day": {
-        "name": "School Day"
-      },
-      "holiday": {
-        "name": "Holiday"
-      },
-      "vacation": {
-        "name": "Vacation"
-      },
-      "holiday_name": {
-        "name": "Holiday Name"
-      },
-      "special_day": {
-        "name": "Special Day"
-      },
-      "next_birthday": {
-        "name": "Next Birthday"
-      },
-      "days_to_birthday": {
-        "name": "Days to Birthday"
-      },
-      "today_birthday": {
-        "name": "Today's Birthday"
-      },
-      "next_family_holiday": {
-        "name": "Next Family Holiday"
-      },
-      "days_to_family_holiday": {
-        "name": "Days to Family Holiday"
-      },
-      "today_family_holiday": {
-        "name": "Today's Family Holiday"
-      },
-      "vacation_name": {
-        "name": "Vacation Name"
-      },
-      "next_holiday": {
-        "name": "Next Holiday"
-      },
-      "next_special_day": {
-        "name": "Next Special Day"
-      },
-      "next_vacation": {
-        "name": "Next Vacation"
-      },
-      "days_to_holiday": {
-        "name": "Days to Holiday"
-      },
-      "days_to_special_day": {
-        "name": "Days to Special Day"
-      },
-      "days_to_vacation": {
-        "name": "Days to Vacation"
-      },
-      "today_day_name": {
-        "name": "Today's Day"
-      },
-      "tomorrow_day_name": {
-        "name": "Tomorrow's Day"
-      }
-    },
-    "calendar": {
-      "holidays": {
-        "name": "Holidays"
-      },
-      "vacations": {
-        "name": "School Vacations"
-      },
-      "combined": {
-        "name": "Holidays & Vacations"
       }
     }
   },

--- a/custom_components/cz_sk_calendar/translations/sk.json
+++ b/custom_components/cz_sk_calendar/translations/sk.json
@@ -30,87 +30,8 @@
           "custom_birthdays": "Vlastné narodeniny",
           "custom_holidays": "Vlastné sviatky",
           "reminder_days": "Koľko dní vopred pripomínať",
-          "reminder_daily": "Pripomínať denne v okne",
-          "custom_events": "Vlastné udalosti (zastaralé)"
+          "reminder_daily": "Pripomínať denne v okne"
         }
-      }
-    }
-  },
-  "entity": {
-    "sensor": {
-      "workday": {
-        "name": "Pracovný deň"
-      },
-      "school_day": {
-        "name": "Školský deň"
-      },
-      "holiday": {
-        "name": "Sviatok"
-      },
-      "vacation": {
-        "name": "Prázdniny"
-      },
-      "holiday_name": {
-        "name": "Názov sviatku"
-      },
-      "special_day": {
-        "name": "Významný deň"
-      },
-      "next_birthday": {
-        "name": "Ďalšie narodeniny"
-      },
-      "days_to_birthday": {
-        "name": "Dní do narodenín"
-      },
-      "today_birthday": {
-        "name": "Dnešné narodeniny"
-      },
-      "next_family_holiday": {
-        "name": "Ďalší rodinný sviatok"
-      },
-      "days_to_family_holiday": {
-        "name": "Dní do rodinného sviatku"
-      },
-      "today_family_holiday": {
-        "name": "Dnešný rodinný sviatok"
-      },
-      "vacation_name": {
-        "name": "Názov prázdnin"
-      },
-      "next_holiday": {
-        "name": "Ďalší sviatok"
-      },
-      "next_special_day": {
-        "name": "Ďalší významný deň"
-      },
-      "next_vacation": {
-        "name": "Ďalšie prázdniny"
-      },
-      "days_to_holiday": {
-        "name": "Dní do sviatku"
-      },
-      "days_to_special_day": {
-        "name": "Dní do významného dňa"
-      },
-      "days_to_vacation": {
-        "name": "Dní do prázdnin"
-      },
-      "today_day_name": {
-        "name": "Dnešný deň"
-      },
-      "tomorrow_day_name": {
-        "name": "Zajtrajší deň"
-      }
-    },
-    "calendar": {
-      "holidays": {
-        "name": "Sviatky"
-      },
-      "vacations": {
-        "name": "Školské prázdniny"
-      },
-      "combined": {
-        "name": "Sviatky a prázdniny"
       }
     }
   },


### PR DESCRIPTION
Options flow:
- CZSKCalendarOptionsFlow dědil z ConfigFlow místo OptionsFlow a dostával config_entry do __init__, což je od HA 2024.11 zastaralé a v novějších verzích už odstraněné. Entry teď poskytuje options flow manager.
- Změna kraje v nastavení se ukládá do entry.options, ale entity četly entry.data, takže se nikdy neprojevila. Přidány pomocné funkce get_configured_country/get_configured_region s fallbackem na entry.data a použity ve všech platformách.

ID entit:
- Zobrazovaná jména jsou lokalizovaná, takže entity_id vycházelo z českého názvu (sensor.pracovni_den) a lišilo se mezi CZ a SK instalacemi. Kalendáře měly navíc has_entity_name=True, takže dostávaly prefix jménem zařízení. Přidán suggested_object_id odvozený z typu entity, díky čemuž jsou ID stabilní a shodná s dokumentací. Existující entity si ID ponechají.

Další opravy:
- Doplněn CONFIG_SCHEMA (config_entry_only_config_schema), HA jinak loguje varování o chybějícím schématu.
- date.today() nahrazeno dt_util.now().date(), aby se respektovala časová zóna nastavená v HA.
- Odstraněna mrtvá sekce entity: z překladů (nikde se nenastavuje translation_key) a nepoužívaný klíč custom_events z options.
- Odstraněn nepoužívaný device_class OCCUPANCY u binary_sensoru pracovního dne, nepoužité importy a mrtvá proměnná region_name v kalendáři.
- Opravena rozbitá indentace v seznamu senzorů.
- README: doplněno 10 chybějících senzorů a tabulka binárních senzorů, opravena ID entit v tabulkách i v příkladech automatizací (používaly tři různá, neexistující schémata) a stavy binárních senzorů on/off.
- Přidán .gitignore, verze zvýšena na 1.1.0.


Claude-Session: https://claude.ai/code/session_012aswf9m7jTJtPL56EJKPip