### PR TITLE
Opravit deklarovanou minimální verzi Home Assistantu

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Jarní prázdniny na Slovensku trvají jeden týden a jsou rozděleny do 3 turnu
 
 ## Instalace
 
+**Požadavky:** Home Assistant 2024.12.0 nebo novější.
+
 ### HACS (doporučeno)
 
 1. Otevřete HACS v Home Assistant

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "CZ/SK School & Work Calendar",
-  "homeassistant": "2023.1.0",
+  "homeassistant": "2024.12.0",
   "render_readme": true,
   "country": ["CZ", "SK"]
 }


### PR DESCRIPTION
hacs.json uváděl 2023.1.0, ale integrace tuto verzi nepodporuje už delší dobu: import ConfigFlowResult z config_entries existuje až od HA 2024.4. Nová OptionsFlow navíc spoléhá na property OptionsFlow.config_entry, kterou poskytuje až HA 2024.12 (do 2024.11 ji měla pouze OptionsFlowWithConfigEntry). Na starším HA by se dialog nastavení rozbil na AttributeError.

Minimum zvýšeno na 2024.12.0 a doplněno do README, aby HACS uživatelům na starším jádru integraci nenabízel.

